### PR TITLE
Introduce docker image and cache versioning with package.json version & fix to set macOptionIsMeta as false in xterm

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,12 +60,12 @@ jobs:
           # Add branch-specific tags
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "ADDITIONAL_TAG=${{ env.DOCKER_IMAGE }}:latest" >> $GITHUB_OUTPUT
-            echo "Using tags: ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}, ${{ env.DOCKER_IMAGE }}:latest"
+            echo "Using tags: ${{ steps.package_version.outputs.VERSION_TAG }}, ${{ env.DOCKER_IMAGE }}:latest"
           elif [ "${{ github.ref }}" = "refs/heads/testing" ]; then
             echo "ADDITIONAL_TAG=${{ env.DOCKER_IMAGE }}:testing" >> $GITHUB_OUTPUT
-            echo "Using tags: ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}, ${{ env.DOCKER_IMAGE }}:testing"
+            echo "Using tags: ${{ steps.package_version.outputs.VERSION_TAG }}, ${{ env.DOCKER_IMAGE }}:testing"
           else
-            echo "Using tag: ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}"
+            echo "Using tag: ${{ steps.package_version.outputs.VERSION_TAG }}"
           fi
 
       - name: Build and Push Multi-Platform Image
@@ -75,7 +75,7 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           push: true
           tags: |
-            ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}
+            ${{ steps.package_version.outputs.VERSION_TAG }}
             ${{ steps.docker_meta.outputs.ADDITIONAL_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,10 +14,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: 'arm64,amd64'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+      
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -25,21 +44,34 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract version from package.json
+        id: package_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
       - name: Set Docker tags
         id: docker_meta
         run: |
-          TAGS="${{ env.DOCKER_IMAGE }}:${{ github.sha }}"
+          TAGS="${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}"
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             TAGS+=" ${{ env.DOCKER_IMAGE }}:latest"
           elif [ "${{ github.ref }}" = "refs/heads/testing" ]; then
             TAGS+=" ${{ env.DOCKER_IMAGE }}:testing"
           fi
-          echo "DOCKER_TAGS=$TAGS" >> $GITHUB_ENV
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
+          echo "Tags to be used: $TAGS"
 
       - name: Build and Push Multi-Platform Image
-        run: |
-          docker buildx create --use
-          docker buildx build --platform ${{ env.PLATFORMS }} \
-            --tag ${{ env.DOCKER_IMAGE }}:${{ github.sha }} \
-            --tag ${{ env.DOCKER_IMAGE }}:latest \
-            --push .
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ env.TAGS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,14 +54,19 @@ jobs:
       - name: Set Docker tags
         id: docker_meta
         run: |
-          TAGS="${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}"
+          # Always add the version tag
+          echo "VERSION_TAG=${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}" >> $GITHUB_OUTPUT
+          
+          # Add branch-specific tags
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            TAGS+=" ${{ env.DOCKER_IMAGE }}:latest"
+            echo "ADDITIONAL_TAG=${{ env.DOCKER_IMAGE }}:latest" >> $GITHUB_OUTPUT
+            echo "Using tags: ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}, ${{ env.DOCKER_IMAGE }}:latest"
           elif [ "${{ github.ref }}" = "refs/heads/testing" ]; then
-            TAGS+=" ${{ env.DOCKER_IMAGE }}:testing"
+            echo "ADDITIONAL_TAG=${{ env.DOCKER_IMAGE }}:testing" >> $GITHUB_OUTPUT
+            echo "Using tags: ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}, ${{ env.DOCKER_IMAGE }}:testing"
+          else
+            echo "Using tag: ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}"
           fi
-          echo "TAGS=$TAGS" >> $GITHUB_ENV
-          echo "Tags to be used: $TAGS"
 
       - name: Build and Push Multi-Platform Image
         uses: docker/build-push-action@v5
@@ -69,7 +74,9 @@ jobs:
           context: .
           platforms: ${{ env.PLATFORMS }}
           push: true
-          tags: ${{ env.TAGS }}
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}
+            ${{ steps.docker_meta.outputs.ADDITIONAL_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,9 +63,9 @@ jobs:
             echo "Using tags: ${{ steps.package_version.outputs.VERSION_TAG }}, ${{ env.DOCKER_IMAGE }}:latest"
           elif [ "${{ github.ref }}" = "refs/heads/testing" ]; then
             echo "ADDITIONAL_TAG=${{ env.DOCKER_IMAGE }}:testing" >> $GITHUB_OUTPUT
-            echo "Using tags: ${{ steps.package_version.outputs.VERSION_TAG }}, ${{ env.DOCKER_IMAGE }}:testing"
+            echo "Using tags: ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}, ${{ env.DOCKER_IMAGE }}:testing"
           else
-            echo "Using tag: ${{ steps.package_version.outputs.VERSION_TAG }}"
+            echo "Using tag: ${{ env.DOCKER_IMAGE }}:${{ steps.package_version.outputs.VERSION }}"
           fi
 
       - name: Build and Push Multi-Platform Image
@@ -75,7 +75,7 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           push: true
           tags: |
-            ${{ steps.package_version.outputs.VERSION_TAG }}
+            ${{ steps.docker_meta.outputs.VERSION_TAG}}
             ${{ steps.docker_meta.outputs.ADDITIONAL_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumbterm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A stupidly simple web-based terminal emulator, with common tools and Starship enabled (via Docker)! 🚀",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumbterm",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "A stupidly simple web-based terminal emulator, with common tools and Starship enabled (via Docker)! 🚀",
   "main": "server.js",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -92,6 +92,7 @@
         </div>
     </main>
     <div class="dumbware-credit">
+        <span id="version-display" class="version-display loading">Loading...</span>
         Built by <a href="https://dumbware.io" target="_blank" rel="noopener noreferrer">DumbWareio</a>
     </div>
     <script type="module" src="index.js"></script>

--- a/public/index.js
+++ b/public/index.js
@@ -187,7 +187,6 @@ document.addEventListener('DOMContentLoaded', () => {
         // Include cacheName if available in config
         if (window.appConfig?.cacheName) {
             message.cacheName = window.appConfig.cacheName;
-            console.log(`Including cacheName in message to service worker: ${window.appConfig.cacheName}`);
         }
         
         // Try to send to the controller if it exists
@@ -615,10 +614,8 @@ document.addEventListener('DOMContentLoaded', () => {
         // Wait for fonts to load
         await waitForFonts();
 
-        // Initialize terminal if needed
-        if (document.querySelector('.terminals-container')) {
-            const terminalManager = new TerminalManager(isMacOS, setupToolTips);
-        }
+        // Initialize terminal
+        const terminalManager = new TerminalManager(isMacOS, setupToolTips);
 
         // Set up tooltips
         const tooltips = document.querySelectorAll('[data-tooltip]');

--- a/public/index.js
+++ b/public/index.js
@@ -1,12 +1,9 @@
 import TerminalManager from "./managers/terminal.js";
+import ServiceWorkerManager from "./managers/serviceWorker.js";
 
 document.addEventListener('DOMContentLoaded', () => {
-    // Shared timeout variable for update process
-    let updateTimeout;
-    // Tracking variables for update notifications
-    let updateNotificationActive = false;
-    let lastCheckedVersionPair = null;
-
+    let serviceWorkerManager;
+    
     async function waitForFonts() {
         // Create a promise that resolves when fonts are loaded
         const fontPromises = [
@@ -133,422 +130,21 @@ document.addEventListener('DOMContentLoaded', () => {
         // Also hide tooltips when clicking anywhere
         document.addEventListener('click', hideAllTooltips);
     }
-
-    /**
-     * Registers the service worker and sets up event listeners
-     */
-    const registerServiceWorker = () => {
-        if (!("serviceWorker" in navigator)) return;
-        
-        // Set version display to loading state until we have version info
-        const versionDisplay = document.getElementById('version-display');
-        if (versionDisplay) {
-            versionDisplay.textContent = 'Loading...';
-            versionDisplay.classList.add('loading');
-        }
-        
-        // Add cache-busting version parameter to service worker URL
-        const swVersion = window.appConfig?.version || new Date().getTime();
-        const swUrl = joinPath(`service-worker.js?v=${swVersion}`);
-        console.log(`Registering service worker with version param: ${swVersion}`);
-        
-        navigator.serviceWorker.register(swUrl)
-            .then(registration => {
-                console.log("Service Worker registered:", registration.scope);
-                
-                // Send the app version to any active service worker
-                if (window.appConfig?.version) {
-                    sendVersionToServiceWorker(window.appConfig.version);
-                }
-                
-                // Check version to update UI immediately after registration
-                checkVersion();
-            })
-            .catch(error => console.error("Service Worker registration failed:", error));
-        
-        // Set up other service worker related listeners
-        setupServiceWorkerMessageHandlers();
-        setupPeriodicVersionCheck();
-    }
-    
-    /**
-     * Sends version information to all possible service worker targets
-     * @param {string} version - Version to send
-     */
-    function sendVersionToServiceWorker(version) {
-        if (!version) return;
-        
-        // Message to send with version and optional cacheName
-        const message = {
-            type: 'SET_VERSION',
-            version: version
-        };
-        
-        // Include cacheName if available in config
-        if (window.appConfig?.cacheName) {
-            message.cacheName = window.appConfig.cacheName;
-        }
-        
-        // Try to send to the controller if it exists
-        if (navigator.serviceWorker.controller) {
-            navigator.serviceWorker.controller.postMessage(message);
-        }
-        
-        // Also send through the ready promise to ensure we reach the active worker
-        navigator.serviceWorker.ready.then(registration => {
-            if (registration.active) {
-                registration.active.postMessage(message);
-            }
-            if (registration.waiting) {
-                registration.waiting.postMessage(message);
-            }
-        });
-    }
-    
-    /**
-     * Sets up message event listeners for the service worker
-     */
-    function setupServiceWorkerMessageHandlers() {
-        navigator.serviceWorker.addEventListener('message', event => {
-            if (!event.data || !event.data.type) return;
-            
-            switch (event.data.type) {
-                case 'UPDATE_AVAILABLE':
-                    // Store cacheName if provided in the message
-                    if (event.data.cacheName) {
-                        console.log(`Received cacheName in update message: ${event.data.cacheName}`);
-                        // Use it as a local cached value for later use
-                        window._receivedCacheName = event.data.cacheName;
-                    }
-                    showUpdateNotification(event.data.currentVersion, event.data.newVersion);
-                    break;
-                    
-                case 'UPDATE_COMPLETE':
-                    handleUpdateComplete(event.data);
-                    break;
-                    
-                case 'CACHE_VERSION_INFO':
-                    // Store cacheName if provided
-                    if (event.data.cacheName) {
-                        console.log(`Received cacheName in version info: ${event.data.cacheName}`);
-                        window._receivedCacheName = event.data.cacheName;
-                    }
-                    updateVersionDisplay(event.data.currentVersion);
-                    break;
-            }
-        });
-    }
-    
-    /**
-     * Sets up periodic version checking when page is visible
-     */
-    function setupPeriodicVersionCheck() {
-        // Check for updates when the page becomes visible
-        document.addEventListener('visibilitychange', () => {
-            if (document.visibilityState === 'visible' && navigator.serviceWorker.controller) {
-                checkVersion();
-            }
-        });
-        
-        // Also check periodically for version updates (every hour)
-        setInterval(() => {
-            if (navigator.serviceWorker.controller) {
-                checkVersion();
-            }
-        }, 60 * 60 * 1000);
-    }
-    
-    /**
-     * Handles update completion messages
-     * @param {Object} data - Update completion data
-     */
-    function handleUpdateComplete(data) {
-        // Clear any pending timeout
-        if (updateTimeout) {
-            clearTimeout(updateTimeout);
-        }
-        
-        // Reset notification tracking state
-        updateNotificationActive = false;
-        lastCheckedVersionPair = null;
-        
-        // Remove any existing update notifications
-        const existingNotifications = document.querySelectorAll('.update-notification');
-        existingNotifications.forEach(notification => notification.remove());
-        
-        if (data.success === false) {
-            // Show error notification
-            const errorNotification = document.createElement('div');
-            errorNotification.className = 'update-notification error';
-            errorNotification.innerHTML = `
-                <p>Update failed: ${data.error || 'Unknown error'}</p>
-                <button onclick="this.parentElement.remove()">Dismiss</button>
-            `;
-            document.body.appendChild(errorNotification);
-            setTimeout(() => errorNotification.remove(), 5000);
-        } else {
-            // Store cacheName if available for future use
-            if (data.cacheName) {
-                console.log(`Caching received cacheName in update complete: ${data.cacheName}`);
-                window._receivedCacheName = data.cacheName;
-            }
-            
-            // First update the version display if version is available
-            if (data.version) {
-                updateVersionDisplay(data.version);
-                
-                // Small delay to ensure UI updates before reload
-                setTimeout(() => {
-                    window.location.reload();
-                }, 100);
-            } else {
-                // Fall back to immediate reload if no version info
-                window.location.reload();
-            }
-        }
-    }
-    
-    /**
-     * Checks for version updates by querying the service worker
-     * Uses direct cache access first, then falls back to service worker messaging
-     */
-    function checkVersion() {
-        // Skip check if an update notification is already active
-        if (updateNotificationActive) {
-            console.log("Update notification already active, skipping version check");
-            return;
-        }
-        
-        // First try to get the version directly from cache
-        getCurrentCacheVersion().then(cacheInfo => {
-            // Check for update directly if we have version info from cache
-            const configVersion = window.appConfig?.version;
-            
-            if (cacheInfo.version && configVersion && 
-                !cacheInfo.isFirstInstall && 
-                shouldShowUpdateNotification(cacheInfo.version, configVersion)) {
-                
-                showUpdateNotification(cacheInfo.version, configVersion);
-                return;
-            }
-            
-            // Only query service worker if we have an active controller
-            if (navigator.serviceWorker.controller) {
-                const messageChannel = new MessageChannel();
-                
-                messageChannel.port1.onmessage = event => {
-                    console.log("Received version info from service worker:", event.data);
-                    
-                    const currentVersion = cacheInfo.version || event.data.currentVersion;
-                    const newVersion = configVersion || event.data.newVersion;
-                    
-                    if (shouldShowUpdateNotification(currentVersion, newVersion) && !cacheInfo.isFirstInstall) {
-                        showUpdateNotification(currentVersion, newVersion);
-                    }
-                };
-                
-                navigator.serviceWorker.controller.postMessage(
-                    { type: 'GET_VERSION' },
-                    [messageChannel.port2]
-                );
-            }
-        }).catch(error => {
-            console.error("Error checking version:", error);
-        });
-    }
-    
-    /**
-     * Determines if an update notification should be shown
-     * @param {string} currentVersion - Current version
-     * @param {string} newVersion - New version
-     * @returns {boolean} True if notification should be shown
-     */
-    function shouldShowUpdateNotification(currentVersion, newVersion) {
-        return (
-            // Both versions must exist
-            currentVersion && newVersion && 
-            // Versions must be different
-            currentVersion !== newVersion && 
-            // Neither version can be the default
-            currentVersion !== "1.0.0" && 
-            newVersion !== "1.0.0"
-        );
-    }
-    
-    /**
-     * Shows a notification when updates are available
-     * @param {string} currentVersion - Current installed version
-     * @param {string} newVersion - New available version
-     */
-    function showUpdateNotification(currentVersion, newVersion) {
-        // Validate versions before showing
-        if (!shouldShowUpdateNotification(currentVersion, newVersion)) {
-            console.log("Update notification skipped - invalid version comparison");
-            return;
-        }
-        
-        // Check if we're already showing a notification for this version pair
-        const versionPair = `${currentVersion}-${newVersion}`;
-        if (updateNotificationActive && lastCheckedVersionPair === versionPair) {
-            console.log("Update notification already active for this version pair, skipping duplicate");
-            return;
-        }
-        
-        // Update tracking variables
-        updateNotificationActive = true;
-        lastCheckedVersionPair = versionPair;
-        
-        // Remove any existing notifications
-        const existingNotifications = document.querySelectorAll('.update-notification');
-        existingNotifications.forEach(notification => notification.remove());
-        
-        // Create new notification
-        const updateNotification = document.createElement('div');
-        updateNotification.className = 'update-notification';
-        updateNotification.innerHTML = `
-            <p>New version v${newVersion} available!</p>
-            <p class="update-details">Current: v${currentVersion}</p>
-            <button id="update-now">Update Now</button>
-            <button id="update-later" class="secondary">Later</button>
-        `;
-        document.body.appendChild(updateNotification);
-        
-        // Set up buttons
-        document.getElementById('update-now').addEventListener('click', () => {
-            handleUpdateRequest(updateNotification);
-        });
-        
-        document.getElementById('update-later').addEventListener('click', () => {
-            updateNotification.remove();
-            updateNotificationActive = false;
-        });
-    }
-    
-    /**
-     * Handles a user request to update the application
-     * @param {HTMLElement} notification - The notification element
-     */
-    function handleUpdateRequest(notification) {
-        // Show loading state
-        const updateButton = notification.querySelector('#update-now');
-        updateButton.innerHTML = 'Updating...';
-        updateButton.disabled = true;
-        
-        // Also update version display to show loading state
-        const versionDisplay = document.getElementById('version-display');
-        if (versionDisplay) {
-            versionDisplay.textContent = 'Updating...';
-            versionDisplay.classList.add('loading');
-        }
-        
-        // Set a timeout to handle cases where the update might hang
-        if (updateTimeout) clearTimeout(updateTimeout);
-        updateTimeout = setTimeout(() => {
-            // Remove any notifications
-            const existingNotifications = document.querySelectorAll('.update-notification');
-            existingNotifications.forEach(notification => notification.remove());
-            
-            // Show timeout error
-            const errorNotification = document.createElement('div');
-            errorNotification.className = 'update-notification error';
-            errorNotification.innerHTML = `
-                <p>Update timed out. Please try again.</p>
-                <button onclick="this.parentElement.remove()">Dismiss</button>
-            `;
-            document.body.appendChild(errorNotification);
-            setTimeout(() => {
-                errorNotification.remove();
-                updateNotificationActive = false;
-            }, 5000);
-            
-            // Restore version display
-            updateVersionDisplay();
-        }, 30000); // 30 second timeout
-        
-        if (navigator.serviceWorker.controller) {
-            // Request the update via service worker
-            navigator.serviceWorker.controller.postMessage({ type: 'PERFORM_UPDATE' });
-        } else {
-            // No service worker controller, try to force reload
-            console.log("No service worker controller, forcing page reload");
-            updateNotificationActive = false;
-            window.location.reload(true);
-        }
-    }
-    
-    /**
-     * Gets the currently installed cache version directly
-     * @returns {Promise<Object>} Cache version information
-     */
-    async function getCurrentCacheVersion() {
-        try {
-            // First check if app config has a cacheName we should use
-            const configCacheName = window.appConfig?.cacheName;
-            
-            const cacheKeys = await caches.keys();
-            // Support both formats: DUMBTERM_PWA_CACHE_V* and DUMBTERM_CACHE_* or any from config
-            const dumbTermCaches = cacheKeys.filter(key => 
-                (configCacheName && key === configCacheName) || 
-                (key.startsWith('DUMBTERM_') && (key.includes('_V') || key.includes('_CACHE_')))
-            );
-            
-            if (dumbTermCaches.length === 0) {
-                console.log('No DumbTerm cache found');
-                return {
-                    version: window.appConfig?.version || null,
-                    cacheName: configCacheName || null,
-                    isFirstInstall: true
-                };
-            }
-            
-            // If config cacheName exists and is in the list, prioritize it
-            let latestCache;
-            if (configCacheName && dumbTermCaches.includes(configCacheName)) {
-                latestCache = configCacheName;
-            } else {
-                // Otherwise sort caches by version to get the latest
-                dumbTermCaches.sort((a, b) => {
-                    // Extract version from different patterns
-                    const getVersion = (cacheName) => {
-                        const vMatch = cacheName.match(/.*_V(.+)$/) || cacheName.match(/DUMBTERM_CACHE_(.+)$/);
-                        return vMatch && vMatch[1] ? vMatch[1] : '';
-                    };
-                    const versionA = getVersion(a);
-                    const versionB = getVersion(b);
-                    return versionB.localeCompare(versionA);
-                });
-                latestCache = dumbTermCaches[0];
-            }
-            
-            // Extract version from cacheName
-            let version;
-            const versionMatch = latestCache.match(/.*_V(.+)$/) || latestCache.match(/DUMBTERM_CACHE_(.+)$/);
-            version = versionMatch && versionMatch[1] ? versionMatch[1] : window.appConfig?.version || null;
-            
-            console.log(`Found cache version: ${version}, cacheName: ${latestCache}`);
-            return {
-                version: version,
-                cacheName: latestCache,
-                isFirstInstall: false,
-                allCaches: dumbTermCaches
-            };
-        } catch (error) {
-            console.error('Error getting cache version:', error);
-            return {
-                version: window.appConfig?.version || null,
-                error: error.message,
-                isFirstInstall: true
-            };
-        }
-    }
     
     /**
      * Updates the UI version display with a specific version
      * @param {string} version - Version to display (optional)
+     * @param {boolean} loading - Whether to show loading state
      */
-    function updateVersionDisplay(version) {
+    function updateVersionDisplay(version, loading = false) {
         const versionDisplay = document.getElementById('version-display');
         if (!versionDisplay) return;
+        
+        if (loading) {
+            versionDisplay.textContent = 'Loading...';
+            versionDisplay.classList.add('loading');
+            return;
+        }
         
         if (version) {
             versionDisplay.textContent = `v${version}`;
@@ -556,38 +152,38 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         
-        // Try to get version info in this order:
-        // 1. From cache
-        // 2. From app config
-        getCurrentCacheVersion()
-            .then(cacheInfo => {
-                if (cacheInfo.version) {
-                    versionDisplay.textContent = `v${cacheInfo.version}`;
-                } else if (window.appConfig?.version) {
-                    versionDisplay.textContent = `v${window.appConfig.version}`;
-                } else {
-                    versionDisplay.textContent = '';
-                }
-                versionDisplay.classList.remove('loading');
-                
-                // Check for updates if needed, but only if no notification is active
-                if (!updateNotificationActive && 
-                    !cacheInfo.isFirstInstall && 
-                    window.appConfig?.version && 
-                    shouldShowUpdateNotification(cacheInfo.version, window.appConfig.version)) {
-                    showUpdateNotification(cacheInfo.version, window.appConfig.version);
-                }
-            })
-            .catch(error => {
-                console.error('Error updating version display:', error);
-                // Fall back to app config version
-                if (window.appConfig?.version) {
-                    versionDisplay.textContent = `v${window.appConfig.version}`;
-                } else {
-                    versionDisplay.textContent = '';
-                }
-                versionDisplay.classList.remove('loading');
-            });
+        // No version provided, try to get from service worker manager or config
+        if (serviceWorkerManager) {
+            serviceWorkerManager.getCurrentCacheVersion()
+                .then(cacheInfo => {
+                    if (cacheInfo.version) {
+                        versionDisplay.textContent = `v${cacheInfo.version}`;
+                    } else if (window.appConfig?.version) {
+                        versionDisplay.textContent = `v${window.appConfig.version}`;
+                    } else {
+                        versionDisplay.textContent = '';
+                    }
+                    versionDisplay.classList.remove('loading');
+                })
+                .catch(error => {
+                    console.error('Error updating version display:', error);
+                    // Fall back to app config version
+                    if (window.appConfig?.version) {
+                        versionDisplay.textContent = `v${window.appConfig.version}`;
+                    } else {
+                        versionDisplay.textContent = '';
+                    }
+                    versionDisplay.classList.remove('loading');
+                });
+        } else {
+            // Fallback if service worker manager isn't initialized
+            if (window.appConfig?.version) {
+                versionDisplay.textContent = `v${window.appConfig.version}`;
+            } else {
+                versionDisplay.textContent = '';
+            }
+            versionDisplay.classList.remove('loading');
+        }
     }
 
     /**
@@ -621,12 +217,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const tooltips = document.querySelectorAll('[data-tooltip]');
         setupToolTips(tooltips);
         
-        // Set up version display and service worker in sequence:
-        // 1. First update version from cache directly
-        updateVersionDisplay();
-        
-        // 2. Then register service worker, which might update the version again
-        registerServiceWorker();
+        // Initialize service worker manager
+        serviceWorkerManager = new ServiceWorkerManager();
+        serviceWorkerManager.initialize(updateVersionDisplay);
     }
 
     initialize().catch(console.error);

--- a/public/index.js
+++ b/public/index.js
@@ -3,6 +3,9 @@ import TerminalManager from "./managers/terminal.js";
 document.addEventListener('DOMContentLoaded', () => {
     // Shared timeout variable for update process
     let updateTimeout;
+    // Tracking variables for update notifications
+    let updateNotificationActive = false;
+    let lastCheckedVersionPair = null;
 
     async function waitForFonts() {
         // Create a promise that resolves when fonts are loaded
@@ -131,160 +134,501 @@ document.addEventListener('DOMContentLoaded', () => {
         document.addEventListener('click', hideAllTooltips);
     }
 
+    /**
+     * Registers the service worker and sets up event listeners
+     */
     const registerServiceWorker = () => {
-        if ("serviceWorker" in navigator) {
-            // Add cache-busting version parameter to service worker URL
-            const swVersion = new Date().getTime(); // Use timestamp as version
-            navigator.serviceWorker.register(joinPath(`service-worker.js?v=${swVersion}`))
-                .then((reg) => {
-                    console.log("Service Worker registered:", reg.scope);
-                    // Check version immediately after registration
-                    checkVersion();
-                })
-                .catch((err) => console.log("Service Worker registration failed:", err));
-                
-            // Listen for version messages from the service worker
-            navigator.serviceWorker.addEventListener('message', (event) => {
-                if (event.data.type === 'UPDATE_AVAILABLE') {
-                    showUpdateNotification(event.data.currentVersion, event.data.newVersion);
-                } else if (event.data.type === 'UPDATE_COMPLETE') {
-                    // Clear any pending timeout
-                    if (updateTimeout) {
-                        clearTimeout(updateTimeout);
-                    }
-                    
-                    // Remove the update notification
-                    const existingNotifications = document.querySelectorAll('.update-notification');
-                    existingNotifications.forEach(notification => notification.remove());
-                    
-                    if (event.data.success === false) {
-                        // Show error notification
-                        const errorNotification = document.createElement('div');
-                        errorNotification.className = 'update-notification error';
-                        errorNotification.innerHTML = `
-                            <p>Update failed: ${event.data.error || 'Unknown error'}</p>
-                            <button onclick="this.parentElement.remove()">Dismiss</button>
-                        `;
-                        document.body.appendChild(errorNotification);
-                        setTimeout(() => errorNotification.remove(), 5000); // Remove after 5 seconds
-                    } else {
-                        // Reload the page after successful update
-                        window.location.reload();
-                    }
-                }
-            });
-            
-            // Check for version updates when the page becomes visible
-            document.addEventListener('visibilitychange', () => {
-                if (document.visibilityState === 'visible' && navigator.serviceWorker.controller) {
-                    checkVersion();
-                }
-            });
-            
-            // Also check periodically for version updates
-            setInterval(() => {
-                if (navigator.serviceWorker.controller) {
-                    checkVersion();
-                }
-            }, 60 * 60 * 1000); // Check every hour
+        if (!("serviceWorker" in navigator)) return;
+        
+        // Set version display to loading state until we have version info
+        const versionDisplay = document.getElementById('version-display');
+        if (versionDisplay) {
+            versionDisplay.textContent = 'Loading...';
+            versionDisplay.classList.add('loading');
         }
+        
+        // Add cache-busting version parameter to service worker URL
+        const swVersion = window.appConfig?.version || new Date().getTime();
+        const swUrl = joinPath(`service-worker.js?v=${swVersion}`);
+        console.log(`Registering service worker with version param: ${swVersion}`);
+        
+        navigator.serviceWorker.register(swUrl)
+            .then(registration => {
+                console.log("Service Worker registered:", registration.scope);
+                
+                // Send the app version to any active service worker
+                if (window.appConfig?.version) {
+                    sendVersionToServiceWorker(window.appConfig.version);
+                }
+                
+                // Check version to update UI immediately after registration
+                checkVersion();
+            })
+            .catch(error => console.error("Service Worker registration failed:", error));
+        
+        // Set up other service worker related listeners
+        setupServiceWorkerMessageHandlers();
+        setupPeriodicVersionCheck();
     }
     
-    // Check the current service worker version
-    function checkVersion() {
-        if (!navigator.serviceWorker.controller) return;
+    /**
+     * Sends version information to all possible service worker targets
+     * @param {string} version - Version to send
+     */
+    function sendVersionToServiceWorker(version) {
+        if (!version) return;
         
-        // Create a message channel for the response
-        const messageChannel = new MessageChannel();
-        
-        // Listen for the response
-        messageChannel.port1.onmessage = (event) => {
-            if (event.data.currentVersion !== event.data.newVersion) {
-                showUpdateNotification(event.data.currentVersion, event.data.newVersion);
-            }
+        // Message to send with version and optional cacheName
+        const message = {
+            type: 'SET_VERSION',
+            version: version
         };
         
-        // Ask the service worker for its version
-        navigator.serviceWorker.controller.postMessage(
-            { type: 'GET_VERSION' },
-            [messageChannel.port2]
-        );
+        // Include cacheName if available in config
+        if (window.appConfig?.cacheName) {
+            message.cacheName = window.appConfig.cacheName;
+            console.log(`Including cacheName in message to service worker: ${window.appConfig.cacheName}`);
+        }
+        
+        // Try to send to the controller if it exists
+        if (navigator.serviceWorker.controller) {
+            navigator.serviceWorker.controller.postMessage(message);
+        }
+        
+        // Also send through the ready promise to ensure we reach the active worker
+        navigator.serviceWorker.ready.then(registration => {
+            if (registration.active) {
+                registration.active.postMessage(message);
+            }
+            if (registration.waiting) {
+                registration.waiting.postMessage(message);
+            }
+        });
     }
     
-    // Show a notification when updates are available
-    function showUpdateNotification(currentVersion, newVersion) {
-        // Remove any existing notifications first
+    /**
+     * Sets up message event listeners for the service worker
+     */
+    function setupServiceWorkerMessageHandlers() {
+        navigator.serviceWorker.addEventListener('message', event => {
+            if (!event.data || !event.data.type) return;
+            
+            switch (event.data.type) {
+                case 'UPDATE_AVAILABLE':
+                    // Store cacheName if provided in the message
+                    if (event.data.cacheName) {
+                        console.log(`Received cacheName in update message: ${event.data.cacheName}`);
+                        // Use it as a local cached value for later use
+                        window._receivedCacheName = event.data.cacheName;
+                    }
+                    showUpdateNotification(event.data.currentVersion, event.data.newVersion);
+                    break;
+                    
+                case 'UPDATE_COMPLETE':
+                    handleUpdateComplete(event.data);
+                    break;
+                    
+                case 'CACHE_VERSION_INFO':
+                    // Store cacheName if provided
+                    if (event.data.cacheName) {
+                        console.log(`Received cacheName in version info: ${event.data.cacheName}`);
+                        window._receivedCacheName = event.data.cacheName;
+                    }
+                    updateVersionDisplay(event.data.currentVersion);
+                    break;
+            }
+        });
+    }
+    
+    /**
+     * Sets up periodic version checking when page is visible
+     */
+    function setupPeriodicVersionCheck() {
+        // Check for updates when the page becomes visible
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible' && navigator.serviceWorker.controller) {
+                checkVersion();
+            }
+        });
+        
+        // Also check periodically for version updates (every hour)
+        setInterval(() => {
+            if (navigator.serviceWorker.controller) {
+                checkVersion();
+            }
+        }, 60 * 60 * 1000);
+    }
+    
+    /**
+     * Handles update completion messages
+     * @param {Object} data - Update completion data
+     */
+    function handleUpdateComplete(data) {
+        // Clear any pending timeout
+        if (updateTimeout) {
+            clearTimeout(updateTimeout);
+        }
+        
+        // Reset notification tracking state
+        updateNotificationActive = false;
+        lastCheckedVersionPair = null;
+        
+        // Remove any existing update notifications
         const existingNotifications = document.querySelectorAll('.update-notification');
         existingNotifications.forEach(notification => notification.remove());
         
+        if (data.success === false) {
+            // Show error notification
+            const errorNotification = document.createElement('div');
+            errorNotification.className = 'update-notification error';
+            errorNotification.innerHTML = `
+                <p>Update failed: ${data.error || 'Unknown error'}</p>
+                <button onclick="this.parentElement.remove()">Dismiss</button>
+            `;
+            document.body.appendChild(errorNotification);
+            setTimeout(() => errorNotification.remove(), 5000);
+        } else {
+            // Store cacheName if available for future use
+            if (data.cacheName) {
+                console.log(`Caching received cacheName in update complete: ${data.cacheName}`);
+                window._receivedCacheName = data.cacheName;
+            }
+            
+            // First update the version display if version is available
+            if (data.version) {
+                updateVersionDisplay(data.version);
+                
+                // Small delay to ensure UI updates before reload
+                setTimeout(() => {
+                    window.location.reload();
+                }, 100);
+            } else {
+                // Fall back to immediate reload if no version info
+                window.location.reload();
+            }
+        }
+    }
+    
+    /**
+     * Checks for version updates by querying the service worker
+     * Uses direct cache access first, then falls back to service worker messaging
+     */
+    function checkVersion() {
+        // Skip check if an update notification is already active
+        if (updateNotificationActive) {
+            console.log("Update notification already active, skipping version check");
+            return;
+        }
+        
+        // First try to get the version directly from cache
+        getCurrentCacheVersion().then(cacheInfo => {
+            // Check for update directly if we have version info from cache
+            const configVersion = window.appConfig?.version;
+            
+            if (cacheInfo.version && configVersion && 
+                !cacheInfo.isFirstInstall && 
+                shouldShowUpdateNotification(cacheInfo.version, configVersion)) {
+                
+                showUpdateNotification(cacheInfo.version, configVersion);
+                return;
+            }
+            
+            // Only query service worker if we have an active controller
+            if (navigator.serviceWorker.controller) {
+                const messageChannel = new MessageChannel();
+                
+                messageChannel.port1.onmessage = event => {
+                    console.log("Received version info from service worker:", event.data);
+                    
+                    const currentVersion = cacheInfo.version || event.data.currentVersion;
+                    const newVersion = configVersion || event.data.newVersion;
+                    
+                    if (shouldShowUpdateNotification(currentVersion, newVersion) && !cacheInfo.isFirstInstall) {
+                        showUpdateNotification(currentVersion, newVersion);
+                    }
+                };
+                
+                navigator.serviceWorker.controller.postMessage(
+                    { type: 'GET_VERSION' },
+                    [messageChannel.port2]
+                );
+            }
+        }).catch(error => {
+            console.error("Error checking version:", error);
+        });
+    }
+    
+    /**
+     * Determines if an update notification should be shown
+     * @param {string} currentVersion - Current version
+     * @param {string} newVersion - New version
+     * @returns {boolean} True if notification should be shown
+     */
+    function shouldShowUpdateNotification(currentVersion, newVersion) {
+        return (
+            // Both versions must exist
+            currentVersion && newVersion && 
+            // Versions must be different
+            currentVersion !== newVersion && 
+            // Neither version can be the default
+            currentVersion !== "1.0.0" && 
+            newVersion !== "1.0.0"
+        );
+    }
+    
+    /**
+     * Shows a notification when updates are available
+     * @param {string} currentVersion - Current installed version
+     * @param {string} newVersion - New available version
+     */
+    function showUpdateNotification(currentVersion, newVersion) {
+        // Validate versions before showing
+        if (!shouldShowUpdateNotification(currentVersion, newVersion)) {
+            console.log("Update notification skipped - invalid version comparison");
+            return;
+        }
+        
+        // Check if we're already showing a notification for this version pair
+        const versionPair = `${currentVersion}-${newVersion}`;
+        if (updateNotificationActive && lastCheckedVersionPair === versionPair) {
+            console.log("Update notification already active for this version pair, skipping duplicate");
+            return;
+        }
+        
+        // Update tracking variables
+        updateNotificationActive = true;
+        lastCheckedVersionPair = versionPair;
+        
+        // Remove any existing notifications
+        const existingNotifications = document.querySelectorAll('.update-notification');
+        existingNotifications.forEach(notification => notification.remove());
+        
+        // Create new notification
         const updateNotification = document.createElement('div');
         updateNotification.className = 'update-notification';
         updateNotification.innerHTML = `
-            <p>New version ${newVersion} available!</p>
+            <p>New version v${newVersion} available!</p>
+            <p class="update-details">Current: v${currentVersion}</p>
             <button id="update-now">Update Now</button>
             <button id="update-later" class="secondary">Later</button>
         `;
         document.body.appendChild(updateNotification);
         
-        document.getElementById('update-now').addEventListener('click', async () => {
-            // Show a loading spinner in the button
-            const updateButton = document.getElementById('update-now');
-            updateButton.innerHTML = 'Updating...';
-            updateButton.disabled = true;
-            
-            if (navigator.serviceWorker.controller) {
-                // Set a timeout to handle cases where the update might hang
-                if (updateTimeout) clearTimeout(updateTimeout);
-                updateTimeout = setTimeout(() => {
-                    const existingNotifications = document.querySelectorAll('.update-notification');
-                    existingNotifications.forEach(notification => notification.remove());
-                    
-                    // Show error notification
-                    const errorNotification = document.createElement('div');
-                    errorNotification.className = 'update-notification error';
-                    errorNotification.innerHTML = `
-                        <p>Update timed out. Please try again.</p>
-                        <button onclick="this.parentElement.remove()">Dismiss</button>
-                    `;
-                    document.body.appendChild(errorNotification);
-                    setTimeout(() => errorNotification.remove(), 5000);
-                }, 30000); // 30 second timeout
-                
-                // Tell service worker to perform the update
-                navigator.serviceWorker.controller.postMessage({ type: 'PERFORM_UPDATE' });
-            }
+        // Set up buttons
+        document.getElementById('update-now').addEventListener('click', () => {
+            handleUpdateRequest(updateNotification);
         });
         
         document.getElementById('update-later').addEventListener('click', () => {
             updateNotification.remove();
+            updateNotificationActive = false;
         });
     }
     
+    /**
+     * Handles a user request to update the application
+     * @param {HTMLElement} notification - The notification element
+     */
+    function handleUpdateRequest(notification) {
+        // Show loading state
+        const updateButton = notification.querySelector('#update-now');
+        updateButton.innerHTML = 'Updating...';
+        updateButton.disabled = true;
+        
+        // Also update version display to show loading state
+        const versionDisplay = document.getElementById('version-display');
+        if (versionDisplay) {
+            versionDisplay.textContent = 'Updating...';
+            versionDisplay.classList.add('loading');
+        }
+        
+        // Set a timeout to handle cases where the update might hang
+        if (updateTimeout) clearTimeout(updateTimeout);
+        updateTimeout = setTimeout(() => {
+            // Remove any notifications
+            const existingNotifications = document.querySelectorAll('.update-notification');
+            existingNotifications.forEach(notification => notification.remove());
+            
+            // Show timeout error
+            const errorNotification = document.createElement('div');
+            errorNotification.className = 'update-notification error';
+            errorNotification.innerHTML = `
+                <p>Update timed out. Please try again.</p>
+                <button onclick="this.parentElement.remove()">Dismiss</button>
+            `;
+            document.body.appendChild(errorNotification);
+            setTimeout(() => {
+                errorNotification.remove();
+                updateNotificationActive = false;
+            }, 5000);
+            
+            // Restore version display
+            updateVersionDisplay();
+        }, 30000); // 30 second timeout
+        
+        if (navigator.serviceWorker.controller) {
+            // Request the update via service worker
+            navigator.serviceWorker.controller.postMessage({ type: 'PERFORM_UPDATE' });
+        } else {
+            // No service worker controller, try to force reload
+            console.log("No service worker controller, forcing page reload");
+            updateNotificationActive = false;
+            window.location.reload(true);
+        }
+    }
+    
+    /**
+     * Gets the currently installed cache version directly
+     * @returns {Promise<Object>} Cache version information
+     */
+    async function getCurrentCacheVersion() {
+        try {
+            // First check if app config has a cacheName we should use
+            const configCacheName = window.appConfig?.cacheName;
+            
+            const cacheKeys = await caches.keys();
+            // Support both formats: DUMBTERM_PWA_CACHE_V* and DUMBTERM_CACHE_* or any from config
+            const dumbTermCaches = cacheKeys.filter(key => 
+                (configCacheName && key === configCacheName) || 
+                (key.startsWith('DUMBTERM_') && (key.includes('_V') || key.includes('_CACHE_')))
+            );
+            
+            if (dumbTermCaches.length === 0) {
+                console.log('No DumbTerm cache found');
+                return {
+                    version: window.appConfig?.version || null,
+                    cacheName: configCacheName || null,
+                    isFirstInstall: true
+                };
+            }
+            
+            // If config cacheName exists and is in the list, prioritize it
+            let latestCache;
+            if (configCacheName && dumbTermCaches.includes(configCacheName)) {
+                latestCache = configCacheName;
+            } else {
+                // Otherwise sort caches by version to get the latest
+                dumbTermCaches.sort((a, b) => {
+                    // Extract version from different patterns
+                    const getVersion = (cacheName) => {
+                        const vMatch = cacheName.match(/.*_V(.+)$/) || cacheName.match(/DUMBTERM_CACHE_(.+)$/);
+                        return vMatch && vMatch[1] ? vMatch[1] : '';
+                    };
+                    const versionA = getVersion(a);
+                    const versionB = getVersion(b);
+                    return versionB.localeCompare(versionA);
+                });
+                latestCache = dumbTermCaches[0];
+            }
+            
+            // Extract version from cacheName
+            let version;
+            const versionMatch = latestCache.match(/.*_V(.+)$/) || latestCache.match(/DUMBTERM_CACHE_(.+)$/);
+            version = versionMatch && versionMatch[1] ? versionMatch[1] : window.appConfig?.version || null;
+            
+            console.log(`Found cache version: ${version}, cacheName: ${latestCache}`);
+            return {
+                version: version,
+                cacheName: latestCache,
+                isFirstInstall: false,
+                allCaches: dumbTermCaches
+            };
+        } catch (error) {
+            console.error('Error getting cache version:', error);
+            return {
+                version: window.appConfig?.version || null,
+                error: error.message,
+                isFirstInstall: true
+            };
+        }
+    }
+    
+    /**
+     * Updates the UI version display with a specific version
+     * @param {string} version - Version to display (optional)
+     */
+    function updateVersionDisplay(version) {
+        const versionDisplay = document.getElementById('version-display');
+        if (!versionDisplay) return;
+        
+        if (version) {
+            versionDisplay.textContent = `v${version}`;
+            versionDisplay.classList.remove('loading');
+            return;
+        }
+        
+        // Try to get version info in this order:
+        // 1. From cache
+        // 2. From app config
+        getCurrentCacheVersion()
+            .then(cacheInfo => {
+                if (cacheInfo.version) {
+                    versionDisplay.textContent = `v${cacheInfo.version}`;
+                } else if (window.appConfig?.version) {
+                    versionDisplay.textContent = `v${window.appConfig.version}`;
+                } else {
+                    versionDisplay.textContent = '';
+                }
+                versionDisplay.classList.remove('loading');
+                
+                // Check for updates if needed, but only if no notification is active
+                if (!updateNotificationActive && 
+                    !cacheInfo.isFirstInstall && 
+                    window.appConfig?.version && 
+                    shouldShowUpdateNotification(cacheInfo.version, window.appConfig.version)) {
+                    showUpdateNotification(cacheInfo.version, window.appConfig.version);
+                }
+            })
+            .catch(error => {
+                console.error('Error updating version display:', error);
+                // Fall back to app config version
+                if (window.appConfig?.version) {
+                    versionDisplay.textContent = `v${window.appConfig.version}`;
+                } else {
+                    versionDisplay.textContent = '';
+                }
+                versionDisplay.classList.remove('loading');
+            });
+    }
+
+    /**
+     * Initializes the application
+     */
     async function initialize() {
+        // Initialize UI components
         initThemeToggle();
+        
         // Set site title
         const siteTitle = window.appConfig?.siteTitle || 'DumbTerm';
         document.getElementById('pageTitle').textContent = siteTitle;
         document.getElementById('siteTitle').textContent = siteTitle;
 
-        // Show demo banner if in demo mode
+        // Configure UI based on app settings
         if (window.appConfig?.isDemoMode) {
             document.getElementById('demo-banner').style.display = 'block';
         }
+        
         if (!window.appConfig?.isPinRequired) {
             document.getElementById("logoutBtn").style.display = 'none';
         }
 
-        // Wait for fonts to load before initializing terminal
+        // Wait for fonts to load
         await waitForFonts();
 
-        // Initialize terminal manager only after fonts are loaded
+        // Initialize terminal if needed
         if (document.querySelector('.terminals-container')) {
             const terminalManager = new TerminalManager(isMacOS, setupToolTips);
         }
 
+        // Set up tooltips
         const tooltips = document.querySelectorAll('[data-tooltip]');
         setupToolTips(tooltips);
+        
+        // Set up version display and service worker in sequence:
+        // 1. First update version from cache directly
+        updateVersionDisplay();
+        
+        // 2. Then register service worker, which might update the version again
         registerServiceWorker();
     }
 

--- a/public/managers/serviceWorker.js
+++ b/public/managers/serviceWorker.js
@@ -1,0 +1,540 @@
+/**
+ * ServiceWorkerManager.js
+ * Manages the registration and communication with the service worker
+ * for version checking, updates, and caching.
+ */
+
+export default class ServiceWorkerManager {
+    constructor() {
+        // Tracking variables
+        this.updateTimeout = null;
+        this.updateNotificationActive = false;
+        this.lastCheckedVersionPair = null;
+        this._receivedCacheName = null;
+        
+        // Initialize with basePath from config
+        this.basePath = window.appConfig?.basePath || '';
+    }
+
+    /**
+     * Initialize the service worker manager
+     * @param {Function} updateVersionDisplayCallback - Callback to update the version display in the UI
+     */
+    initialize(updateVersionDisplayCallback) {
+        if (!("serviceWorker" in navigator)) {
+            // If service workers are not supported, still update the version display with app config
+            if (updateVersionDisplayCallback && window.appConfig?.version) {
+                updateVersionDisplayCallback(window.appConfig.version);
+            }
+            return;
+        }
+        
+        this.updateVersionDisplayCallback = updateVersionDisplayCallback;
+        
+        // Set up the service worker
+        this.registerServiceWorker();
+        this.setupServiceWorkerMessageHandlers();
+        this.setupPeriodicVersionCheck();
+
+        // Immediately check for version in cache and update display, don't wait for service worker
+        this.getCurrentCacheVersion().then(cacheInfo => {
+            if (cacheInfo.version && this.updateVersionDisplayCallback) {
+                this.updateVersionDisplayCallback(cacheInfo.version);
+            } else {
+                // Do a more comprehensive check through the service worker
+                this.checkVersion();
+            }
+        }).catch(() => {
+            // If there's an error getting the cache version, fall back to the regular check
+            this.checkVersion();
+        });
+        
+        // Set a timeout to ensure the version display is updated even if service worker is delayed
+        setTimeout(() => {
+            if (this.updateVersionDisplayCallback) {
+                const versionDisplay = document.getElementById('version-display');
+                if (versionDisplay && versionDisplay.classList.contains('loading')) {
+                    console.log('Version display still loading after timeout, using app config version');
+                    this.updateVersionDisplayCallback(window.appConfig?.version || "");
+                }
+            }
+        }, 2000); // 2 second timeout
+    }
+
+    /**
+     * Registers the service worker
+     */
+    registerServiceWorker() {
+        // Set version display to loading state until we have version info
+        if (this.updateVersionDisplayCallback) {
+            this.updateVersionDisplayCallback(null, true); // true indicates loading state
+        }
+        
+        // Add cache-busting version parameter to service worker URL
+        const swVersion = window.appConfig?.version || new Date().getTime();
+        const swUrl = this.joinPath(`service-worker.js?v=${swVersion}`);
+        console.log(`Registering service worker with version param: ${swVersion}`);
+        
+        navigator.serviceWorker.register(swUrl)
+            .then(registration => {
+                console.log("Service Worker registered:", registration.scope);
+                
+                // Check if a service worker is already controlling the page
+                const isFirstLoad = !navigator.serviceWorker.controller;
+                
+                // Send the app version to any active service worker
+                if (window.appConfig?.version) {
+                    this.sendVersionToServiceWorker(window.appConfig.version);
+                }
+                
+                // On first load or hard reload, we need to be more proactive
+                if (isFirstLoad) {
+                    console.log("First load or hard reload detected - checking cache directly");
+                    // First immediately try to get version from cache
+                    this.getCurrentCacheVersion().then(cacheInfo => {
+                        if (cacheInfo.version && this.updateVersionDisplayCallback) {
+                            console.log(`Updating version display with cache version: ${cacheInfo.version}`);
+                            this.updateVersionDisplayCallback(cacheInfo.version);
+                        } else if (window.appConfig?.version && this.updateVersionDisplayCallback) {
+                            // If no cache version, fall back to app config version
+                            console.log(`No cache version found, using app config version: ${window.appConfig.version}`);
+                            this.updateVersionDisplayCallback(window.appConfig.version);
+                        }
+                    }).catch(error => {
+                        console.error("Error getting cache version:", error);
+                        // Fall back to app config version on error
+                        if (window.appConfig?.version && this.updateVersionDisplayCallback) {
+                            this.updateVersionDisplayCallback(window.appConfig.version);
+                        }
+                    });
+                } else {
+                    // Normal load (not hard reload), use the regular check
+                    this.checkVersion();
+                }
+            })
+            .catch(error => console.error("Service Worker registration failed:", error));
+    }
+
+    /**
+     * Sets up message event listeners for the service worker
+     */
+    setupServiceWorkerMessageHandlers() {
+        navigator.serviceWorker.addEventListener('message', event => {
+            if (!event.data || !event.data.type) return;
+            
+            switch (event.data.type) {
+                case 'UPDATE_AVAILABLE':
+                    // Store cacheName if provided in the message
+                    if (event.data.cacheName) {
+                        console.log(`Received cacheName in update message: ${event.data.cacheName}`);
+                        // Use it as a local cached value for later use
+                        this._receivedCacheName = event.data.cacheName;
+                    }
+                    this.showUpdateNotification(event.data.currentVersion, event.data.newVersion);
+                    break;
+                    
+                case 'UPDATE_COMPLETE':
+                    this.handleUpdateComplete(event.data);
+                    break;
+                    
+                case 'CACHE_VERSION_INFO':
+                    // Store cacheName if provided
+                    if (event.data.cacheName) {
+                        console.log(`Received cacheName in version info: ${event.data.cacheName}`);
+                        this._receivedCacheName = event.data.cacheName;
+                    }
+                    // Update the version display
+                    if (this.updateVersionDisplayCallback) {
+                        this.updateVersionDisplayCallback(event.data.currentVersion);
+                    }
+                    break;
+            }
+        });
+    }
+
+    /**
+     * Sets up periodic version checking when page is visible
+     */
+    setupPeriodicVersionCheck() {
+        // Check for updates when the page becomes visible
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible' && navigator.serviceWorker.controller) {
+                this.checkVersion();
+            }
+        });
+        
+        // Also check periodically for version updates (every hour)
+        setInterval(() => {
+            if (navigator.serviceWorker.controller) {
+                this.checkVersion();
+            }
+        }, 60 * 60 * 1000);
+    }
+
+    /**
+     * Sends version information to all possible service worker targets
+     * @param {string} version - Version to send
+     */
+    sendVersionToServiceWorker(version) {
+        if (!version) return;
+        
+        // Message to send with version and optional cacheName
+        const message = {
+            type: 'SET_VERSION',
+            version: version
+        };
+        
+        // Include cacheName if available in config
+        if (window.appConfig?.cacheName) {
+            message.cacheName = window.appConfig.cacheName;
+            console.log(`Including cacheName in message to service worker: ${window.appConfig.cacheName}`);
+        }
+        
+        // Try to send to the controller if it exists
+        if (navigator.serviceWorker.controller) {
+            navigator.serviceWorker.controller.postMessage(message);
+        }
+        
+        // Also send through the ready promise to ensure we reach the active worker
+        navigator.serviceWorker.ready.then(registration => {
+            if (registration.active) {
+                registration.active.postMessage(message);
+            }
+            if (registration.waiting) {
+                registration.waiting.postMessage(message);
+            }
+        });
+    }
+
+    /**
+     * Checks for version updates by querying the service worker
+     * Uses direct cache access first, then falls back to service worker messaging
+     */
+    checkVersion() {
+        // Skip check if an update notification is already active
+        if (this.updateNotificationActive) {
+            console.log("Update notification already active, skipping version check");
+            return;
+        }
+        
+        // First try to get the version directly from cache
+        this.getCurrentCacheVersion().then(cacheInfo => {
+            // Check for update directly if we have version info from cache
+            const configVersion = window.appConfig?.version;
+            
+            if (cacheInfo.version && configVersion && 
+                !cacheInfo.isFirstInstall && 
+                this.shouldShowUpdateNotification(cacheInfo.version, configVersion)) {
+                
+                this.showUpdateNotification(cacheInfo.version, configVersion);
+                return;
+            }
+            
+            // Only query service worker if we have an active controller
+            if (navigator.serviceWorker.controller) {
+                const messageChannel = new MessageChannel();
+                
+                messageChannel.port1.onmessage = event => {
+                    console.log("Received version info from service worker:", event.data);
+                    
+                    const currentVersion = cacheInfo.version || event.data.currentVersion;
+                    const newVersion = configVersion || event.data.newVersion;
+                    
+                    if (this.shouldShowUpdateNotification(currentVersion, newVersion) && !cacheInfo.isFirstInstall) {
+                        this.showUpdateNotification(currentVersion, newVersion);
+                    }
+                };
+                
+                navigator.serviceWorker.controller.postMessage(
+                    { type: 'GET_VERSION' },
+                    [messageChannel.port2]
+                );
+            }
+        }).catch(error => {
+            console.error("Error checking version:", error);
+        });
+    }
+
+    /**
+     * Gets the currently installed cache version directly
+     * @returns {Promise<Object>} Cache version information
+     */
+    async getCurrentCacheVersion() {
+        try {
+            console.log('Attempting to get cache version directly from cache storage');
+            
+            // First check if we already have a cached version from service worker messages
+            if (this._receivedCacheName) {
+                console.log(`Using previously received cacheName: ${this._receivedCacheName}`);
+                // Try to extract version from the cached cacheName
+                const versionMatch = this._receivedCacheName.match(/.*_V(.+)$/) || 
+                                    this._receivedCacheName.match(/DUMBTERM_CACHE_(.+)$/);
+                
+                if (versionMatch && versionMatch[1]) {
+                    const version = versionMatch[1];
+                    console.log(`Extracted version from cached cacheName: ${version}`);
+                    return {
+                        version: version,
+                        cacheName: this._receivedCacheName,
+                        isFirstInstall: false
+                    };
+                }
+            }
+            
+            // Get version from cache storage
+            const configCacheName = window.appConfig?.cacheName;
+            
+            const cacheKeys = await caches.keys();
+            console.log('Available caches:', cacheKeys);
+            
+            // Support both formats: DUMBTERM_PWA_CACHE_V* and DUMBTERM_CACHE_* or any from config
+            const dumbTermCaches = cacheKeys.filter(key => 
+                (configCacheName && key === configCacheName) || 
+                (key.startsWith('DUMBTERM_') && (key.includes('_V') || key.includes('_CACHE_')))
+            );
+            
+            if (dumbTermCaches.length === 0) {
+                console.log('No DumbTerm cache found');
+                return {
+                    version: window.appConfig?.version || null,
+                    cacheName: configCacheName || null,
+                    isFirstInstall: true
+                };
+            }
+            
+            // If config cacheName exists and is in the list, prioritize it
+            let latestCache;
+            if (configCacheName && dumbTermCaches.includes(configCacheName)) {
+                latestCache = configCacheName;
+                console.log(`Using config-specified cacheName: ${latestCache}`);
+            } else {
+                // Otherwise sort caches by version to get the latest
+                dumbTermCaches.sort((a, b) => {
+                    // Extract version from different patterns
+                    const getVersion = (cacheName) => {
+                        const vMatch = cacheName.match(/.*_V(.+)$/) || cacheName.match(/DUMBTERM_CACHE_(.+)$/);
+                        return vMatch && vMatch[1] ? vMatch[1] : '';
+                    };
+                    const versionA = getVersion(a);
+                    const versionB = getVersion(b);
+                    return versionB.localeCompare(versionA);
+                });
+                latestCache = dumbTermCaches[0];
+                console.log(`Selected latest cache: ${latestCache}`);
+            }
+            
+            // Extract version from cacheName
+            let version;
+            const versionMatch = latestCache.match(/.*_V(.+)$/) || latestCache.match(/DUMBTERM_CACHE_(.+)$/);
+            version = versionMatch && versionMatch[1] ? versionMatch[1] : window.appConfig?.version || null;
+            
+            console.log(`Found cache version: ${version}, cacheName: ${latestCache}`);
+            
+            // Store the cacheName for future use
+            this._receivedCacheName = latestCache;
+            
+            return {
+                version: version,
+                cacheName: latestCache,
+                isFirstInstall: false,
+                allCaches: dumbTermCaches
+            };
+        } catch (error) {
+            console.error('Error getting cache version:', error);
+            
+            // On error, fall back to app config
+            const fallbackVersion = window.appConfig?.version || null;
+            console.log(`Falling back to app config version: ${fallbackVersion}`);
+            
+            return {
+                version: fallbackVersion,
+                error: error.message,
+                isFirstInstall: true
+            };
+        }
+    }
+
+    /**
+     * Determines if an update notification should be shown
+     * @param {string} currentVersion - Current version
+     * @param {string} newVersion - New version
+     * @returns {boolean} True if notification should be shown
+     */
+    shouldShowUpdateNotification(currentVersion, newVersion) {
+        return (
+            // Both versions must exist
+            currentVersion && newVersion && 
+            // Versions must be different
+            currentVersion !== newVersion && 
+            // Neither version can be the default
+            currentVersion !== "1.0.0" && 
+            newVersion !== "1.0.0"
+        );
+    }
+
+    /**
+     * Shows a notification when updates are available
+     * @param {string} currentVersion - Current installed version
+     * @param {string} newVersion - New available version
+     */
+    showUpdateNotification(currentVersion, newVersion) {
+        // Validate versions before showing
+        if (!this.shouldShowUpdateNotification(currentVersion, newVersion)) {
+            console.log("Update notification skipped - invalid version comparison");
+            return;
+        }
+        
+        // Check if we're already showing a notification for this version pair
+        const versionPair = `${currentVersion}-${newVersion}`;
+        if (this.updateNotificationActive && this.lastCheckedVersionPair === versionPair) {
+            console.log("Update notification already active for this version pair, skipping duplicate");
+            return;
+        }
+        
+        // Update tracking variables
+        this.updateNotificationActive = true;
+        this.lastCheckedVersionPair = versionPair;
+        
+        // Remove any existing notifications
+        const existingNotifications = document.querySelectorAll('.update-notification');
+        existingNotifications.forEach(notification => notification.remove());
+        
+        // Create new notification
+        const updateNotification = document.createElement('div');
+        updateNotification.className = 'update-notification';
+        updateNotification.innerHTML = `
+            <p>New version v${newVersion} available!</p>
+            <p class="update-details">Current: v${currentVersion}</p>
+            <button id="update-now">Update Now</button>
+            <button id="update-later" class="secondary">Later</button>
+        `;
+        document.body.appendChild(updateNotification);
+        
+        // Set up buttons
+        document.getElementById('update-now').addEventListener('click', () => {
+            this.handleUpdateRequest(updateNotification);
+        });
+        
+        document.getElementById('update-later').addEventListener('click', () => {
+            updateNotification.remove();
+            this.updateNotificationActive = false;
+        });
+    }
+
+    /**
+     * Handles a user request to update the application
+     * @param {HTMLElement} notification - The notification element
+     */
+    handleUpdateRequest(notification) {
+        // Show loading state
+        const updateButton = notification.querySelector('#update-now');
+        updateButton.innerHTML = 'Updating...';
+        updateButton.disabled = true;
+        
+        // Also update version display to show loading state
+        if (this.updateVersionDisplayCallback) {
+            this.updateVersionDisplayCallback(null, true); // true indicates loading state
+        }
+        
+        // Set a timeout to handle cases where the update might hang
+        if (this.updateTimeout) clearTimeout(this.updateTimeout);
+        this.updateTimeout = setTimeout(() => {
+            // Remove any notifications
+            const existingNotifications = document.querySelectorAll('.update-notification');
+            existingNotifications.forEach(notification => notification.remove());
+            
+            // Show timeout error
+            const errorNotification = document.createElement('div');
+            errorNotification.className = 'update-notification error';
+            errorNotification.innerHTML = `
+                <p>Update timed out. Please try again.</p>
+                <button onclick="this.parentElement.remove()">Dismiss</button>
+            `;
+            document.body.appendChild(errorNotification);
+            setTimeout(() => {
+                errorNotification.remove();
+                this.updateNotificationActive = false;
+            }, 5000);
+            
+            // Restore version display
+            if (this.updateVersionDisplayCallback) {
+                this.updateVersionDisplayCallback();
+            }
+        }, 30000); // 30 second timeout
+        
+        if (navigator.serviceWorker.controller) {
+            // Request the update via service worker
+            navigator.serviceWorker.controller.postMessage({ type: 'PERFORM_UPDATE' });
+        } else {
+            // No service worker controller, try to force reload
+            console.log("No service worker controller, forcing page reload");
+            this.updateNotificationActive = false;
+            window.location.reload(true);
+        }
+    }
+
+    /**
+     * Handles update completion messages
+     * @param {Object} data - Update completion data
+     */
+    handleUpdateComplete(data) {
+        // Clear any pending timeout
+        if (this.updateTimeout) {
+            clearTimeout(this.updateTimeout);
+            this.updateTimeout = null;
+        }
+        
+        // Reset notification tracking state
+        this.updateNotificationActive = false;
+        this.lastCheckedVersionPair = null;
+        
+        // Remove any existing update notifications
+        const existingNotifications = document.querySelectorAll('.update-notification');
+        existingNotifications.forEach(notification => notification.remove());
+        
+        if (data.success === false) {
+            // Show error notification
+            const errorNotification = document.createElement('div');
+            errorNotification.className = 'update-notification error';
+            errorNotification.innerHTML = `
+                <p>Update failed: ${data.error || 'Unknown error'}</p>
+                <button onclick="this.parentElement.remove()">Dismiss</button>
+            `;
+            document.body.appendChild(errorNotification);
+            setTimeout(() => errorNotification.remove(), 5000);
+        } else {
+            // Store cacheName if available for future use
+            if (data.cacheName) {
+                console.log(`Caching received cacheName in update complete: ${data.cacheName}`);
+                this._receivedCacheName = data.cacheName;
+            }
+            
+            // First update the version display if version is available
+            if (data.version && this.updateVersionDisplayCallback) {
+                this.updateVersionDisplayCallback(data.version);
+                
+                // Small delay to ensure UI updates before reload
+                setTimeout(() => {
+                    window.location.reload();
+                }, 100);
+            } else {
+                // Fall back to immediate reload if no version info
+                window.location.reload();
+            }
+        }
+    }
+
+    /**
+     * Helper function to join paths with base path
+     * @param {string} path - Path to join with base path
+     * @returns {string} Joined path
+     */
+    joinPath(path) {
+        // Remove any leading slash from path and trailing slash from basePath
+        const cleanPath = path.replace(/^\/+/, '');
+        const cleanBase = this.basePath.replace(/\/+$/, '');
+        
+        // Join with single slash
+        return cleanBase ? `${cleanBase}/${cleanPath}` : cleanPath;
+    }
+}

--- a/public/managers/terminal.js
+++ b/public/managers/terminal.js
@@ -593,7 +593,7 @@ export default class TerminalManager {
                 brightWhite: '#FFFFFF'
             },
             allowTransparency: true,
-            macOptionIsMeta: true,
+            macOptionIsMeta: false,
             scrollback: 5000,
             minimumContrastRatio: 50,
             cursorStyle: 'block',

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -68,7 +68,7 @@ async function initializeVersion() {
             } else if (appConfig.version) {
                 console.log(`Found version in config.js: ${appConfig.version}`);
                 CACHE_VERSION = appConfig.version;
-                CACHE_NAME = `DUMBTERM_CACHE_V${CACHE_VERSION}`;
+                CACHE_NAME = appConfig.cacheName || `DUMBTERM_CACHE_V${CACHE_VERSION}`; // Fallback format
                 return CACHE_VERSION;
             }
         }
@@ -103,7 +103,7 @@ async function checkCacheVersion() {
     // Find any existing DumbTerm cache - support both formats: DUMBTERM_PWA_CACHE_V* and DUMBTERM_CACHE_V*
     const existingCache = keys.find(key => key === CACHE_NAME) || 
                          keys.find(key => key.startsWith('DUMBTERM_') && 
-                                        key.includes('_CACHE_V'));
+                                        key.includes('_CACHE_') || key.includes('V'));
     
     // Extract version from cache name
     let existingVersion = null;
@@ -119,7 +119,7 @@ async function checkCacheVersion() {
     // Check for old versions - be flexible with the cache naming format
     const oldCaches = keys.filter(key => 
         key !== CACHE_NAME && key.startsWith('DUMBTERM_') && 
-        key.includes('_CACHE_V')
+        key.includes('_CACHE_') || key.includes('V')
     );
     
     console.log(
@@ -432,8 +432,8 @@ async function handleSetVersion(version, cacheName) {
             // Try to get cache name from config as fallback
             try {
                 const appConfig = await getAppConfig();
-                if (appConfig && appConfig.cacheName) {
-                    CACHE_NAME = appConfig.cacheName;
+                if (appConfig) {
+                    CACHE_NAME = appConfig.cacheName || `DUMBTERM_CACHE_V${CACHE_VERSION}`;
                     console.log(`Using cacheName from config: ${CACHE_NAME}`);
                 } else {
                     // Fall back to constructed cache name if needed

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -102,8 +102,7 @@ async function checkCacheVersion() {
     
     // Find any existing DumbTerm cache - support both formats: DUMBTERM_PWA_CACHE_V* and DUMBTERM_CACHE_V*
     const existingCache = keys.find(key => key === CACHE_NAME) || 
-                         keys.find(key => key.startsWith('DUMBTERM_') && 
-                                        key.includes('_CACHE_') || key.includes('V'));
+                         keys.find(key => key.startsWith('DUMBTERM_CACHE'));
     
     // Extract version from cache name
     let existingVersion = null;
@@ -119,7 +118,7 @@ async function checkCacheVersion() {
     // Check for old versions - be flexible with the cache naming format
     const oldCaches = keys.filter(key => 
         key !== CACHE_NAME && key.startsWith('DUMBTERM_') && 
-        key.includes('_CACHE_') || key.includes('V')
+        (key.includes('_CACHE_') || key.includes('V'))
     );
     
     console.log(

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -36,15 +36,12 @@ async function getAppConfig() {
  */
 async function initializeVersion() {
     console.log("Initializing service worker version...");
-    
     try {
-        // 1. First try URL parameter (highest priority)
-        const urlVersion = new URL(self.location.href).searchParams.get('v');
-        if (urlVersion && urlVersion !== "1.0.0") {
-            console.log(`Found version in URL: ${urlVersion}`);
-            CACHE_VERSION = urlVersion;
+        const { currentCacheExists, existingVersion } = await checkCacheVersion();
+        if (currentCacheExists && existingVersion) {
+            CACHE_VERSION = existingVersion;
             CACHE_NAME = `DUMBTERM_CACHE_V${CACHE_VERSION}`; // Fallback format
-            return CACHE_VERSION;
+            return existingVersion;
         }
         
         // 2. Try getting from config.js (second priority)
@@ -117,8 +114,8 @@ async function checkCacheVersion() {
     
     // Check for old versions - be flexible with the cache naming format
     const oldCaches = keys.filter(key => 
-        key !== CACHE_NAME && key.startsWith('DUMBTERM_') && 
-        (key.includes('_CACHE_') || key.includes('V'))
+        key !== CACHE_NAME && (key.startsWith('DUMBTERM_') && 
+        ((key.includes('_CACHE_') || key.includes('PWA_CACHE')) && key.includes('V'))) 
     );
     
     console.log(

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,62 +1,202 @@
-const CACHE_VERSION = "1.0.0"; // Increment this with each significant change
-const CACHE_NAME = `DUMBTERM_PWA_CACHE_V${CACHE_VERSION}`;
+// Core service worker configuration
+let CACHE_VERSION = "1.0.0"; // Default fallback version
+let CACHE_NAME = `DUMBTERM_CACHE_V${CACHE_VERSION}`; // Default format, will be overridden
 const ASSETS_TO_CACHE = [];
 const BASE_PATH = self.registration.scope;
 
-// Helper to prepend base path to URLs that need it
+/**
+ * Gets app configuration from config.js
+ * @returns {Promise<Object|null>} App configuration or null if retrieval fails
+ */
+async function getAppConfig() {
+    try {
+        const response = await fetch(getAssetPath('config.js'));
+        if (!response.ok) throw new Error(`Failed to fetch config: ${response.status}`);
+        
+        const configText = await response.text();
+        const configJson = configText.match(/window\.appConfig\s*=\s*({[\s\S]*?});/);
+        
+        if (configJson && configJson[1]) {
+            return JSON.parse(configJson[1]);
+        }
+        throw new Error('Could not extract config from config.js');
+    } catch (error) {
+        console.error('Error fetching app config:', error);
+        return null;
+    }
+}
+
+/**
+ * Initializes service worker version from different sources in order of priority:
+ * 1. URL query parameter 
+ * 2. App config from config.js
+ * 3. Default version (1.0.0)
+ * 
+ * @returns {Promise<string>} The determined version
+ */
+async function initializeVersion() {
+    console.log("Initializing service worker version...");
+    
+    try {
+        // 1. First try URL parameter (highest priority)
+        const urlVersion = new URL(self.location.href).searchParams.get('v');
+        if (urlVersion && urlVersion !== "1.0.0") {
+            console.log(`Found version in URL: ${urlVersion}`);
+            CACHE_VERSION = urlVersion;
+            CACHE_NAME = `DUMBTERM_CACHE_V${CACHE_VERSION}`; // Fallback format
+            return CACHE_VERSION;
+        }
+        
+        // 2. Try getting from config.js (second priority)
+        const appConfig = await getAppConfig();
+        if (appConfig) {
+            if (appConfig.cacheName) {
+                console.log(`Found cacheName in config.js: ${appConfig.cacheName}`);
+                CACHE_NAME = appConfig.cacheName;
+                
+                // Extract version from cacheName if possible
+                const versionMatch = CACHE_NAME.match(/.*_V(.+)$/);
+                if (versionMatch && versionMatch[1]) {
+                    CACHE_VERSION = versionMatch[1];
+                    console.log(`Extracted version from cacheName: ${CACHE_VERSION}`);
+                } else if (appConfig.version) {
+                    CACHE_VERSION = appConfig.version;
+                    console.log(`Using version from config.js: ${CACHE_VERSION}`);
+                }
+                
+                return CACHE_VERSION;
+            } else if (appConfig.version) {
+                console.log(`Found version in config.js: ${appConfig.version}`);
+                CACHE_VERSION = appConfig.version;
+                CACHE_NAME = `DUMBTERM_CACHE_V${CACHE_VERSION}`;
+                return CACHE_VERSION;
+            }
+        }
+    } catch (error) {
+        console.error("Error initializing version:", error);
+    }
+    
+    // If we reach here, we're using the default version
+    console.log(`Using default version: ${CACHE_VERSION}`);
+    return CACHE_VERSION;
+}
+
+/**
+ * Helper to prepend base path to URLs that need it
+ * @param {string} url - URL to prepend base path to
+ * @returns {string} URL with base path prepended
+ */
 function getAssetPath(url) {
-    // If the URL is external (starts with http:// or https://), don't modify it
     if (url.startsWith('http://') || url.startsWith('https://')) {
         return url;
     }
-    // Remove any leading slashes and join with base path
     return `${BASE_PATH}${url.replace(/^\/+/, '')}`;
 }
 
-// Check if cache exists and what version it is
+/**
+ * Checks for existing caches and their versions
+ * @returns {Promise<Object>} Cache status information
+ */
 async function checkCacheVersion() {
     const keys = await caches.keys();
     
-    // Find any existing DumbTerm cache
-    const existingCache = keys.find(key => key.startsWith('DUMBTERM_PWA_CACHE'));
-    const existingVersion = existingCache ? existingCache.split('V')[1] : null;
+    // Find any existing DumbTerm cache - support both formats: DUMBTERM_PWA_CACHE_V* and DUMBTERM_CACHE_V*
+    const existingCache = keys.find(key => key === CACHE_NAME) || 
+                         keys.find(key => key.startsWith('DUMBTERM_') && 
+                                        key.includes('_CACHE_V'));
+    
+    // Extract version from cache name
+    let existingVersion = null;
+    if (existingCache) {
+        // Try to extract version from different cache name formats
+        const versionMatch = existingCache.match(/.*_V(.+)$/) || existingCache.match(/DUMBTERM_CACHE_(.+)$/);
+        existingVersion = versionMatch && versionMatch[1] ? versionMatch[1] : null;
+    }
     
     // Check if current version cache exists
     const currentCacheExists = keys.includes(CACHE_NAME);
     
-    // Check for old versions
-    const oldCaches = keys.filter(key => key !== CACHE_NAME && key.startsWith('DUMBTERM_PWA_CACHE'));
-    const hasOldVersions = oldCaches.length > 0;
+    // Check for old versions - be flexible with the cache naming format
+    const oldCaches = keys.filter(key => 
+        key !== CACHE_NAME && key.startsWith('DUMBTERM_') && 
+        key.includes('_CACHE_V')
+    );
+    
+    console.log(
+        `Cache check: existingVersion=${existingVersion}, ` +
+        `currentCacheExists=${currentCacheExists}, hasOldVersions=${oldCaches.length > 0}`
+    );
     
     return {
         currentCacheExists,
-        hasOldVersions,
         oldCaches,
-        existingVersion
+        existingVersion,
+        isFirstInstall: !existingCache
     };
 }
 
-// Function to notify clients about version status
-async function notifyClients() {
-    const { existingVersion } = await checkCacheVersion();
-    if (existingVersion !== CACHE_VERSION) {
-        self.clients.matchAll().then(clients => {
-            clients.forEach(client => {
-                client.postMessage({
-                    type: 'UPDATE_AVAILABLE',
-                    currentVersion: existingVersion,
-                    newVersion: CACHE_VERSION
-                });
-            });
-        });
-    }
+/**
+ * Determines if an update notification should be shown
+ * @param {string} currentVersion - Current installed version
+ * @param {string} newVersion - New available version
+ * @returns {boolean} True if update notification should be shown
+ */
+function shouldShowUpdateNotification(currentVersion, newVersion) {
+    return (
+        // Both versions must be valid
+        currentVersion && newVersion &&
+        // Versions must be different
+        currentVersion !== newVersion &&
+        // Neither can be the default version
+        currentVersion !== "1.0.0" && 
+        newVersion !== "1.0.0"
+    );
 }
 
-const preload = async () => {
+/**
+ * Notifies connected clients about version status
+ * @returns {Promise<void>}
+ */
+async function notifyClients() {
+    const { existingVersion } = await checkCacheVersion();
+    
+    self.clients.matchAll().then(clients => {
+        clients.forEach(client => {
+            // Always inform about current version
+            client.postMessage({
+                type: 'CACHE_VERSION_INFO',
+                currentVersion: existingVersion || CACHE_VERSION
+            });
+            
+            // Only send update notification for non-first-time installs with different versions
+            // But don't send both messages at once - just send UPDATE_AVAILABLE
+            // which will trigger the update notification flow
+            if (shouldShowUpdateNotification(existingVersion, CACHE_VERSION)) {
+                console.log(`Sending update notification: current=${existingVersion}, new=${CACHE_VERSION}`);
+                
+                // Wait a brief moment before sending to ensure client is ready
+                setTimeout(() => {
+                    client.postMessage({
+                        type: 'UPDATE_AVAILABLE',
+                        currentVersion: existingVersion,
+                        newVersion: CACHE_VERSION,
+                        cacheName: CACHE_NAME
+                    });
+                }, 300);
+            }
+        });
+    });
+}
+
+/**
+ * Handles initial setup for service worker caching
+ * @returns {Promise<void>}
+ */
+async function preload() {
     console.log("Preparing to install web app cache");
     
     // Check cache status
-    const { currentCacheExists, existingVersion } = await checkCacheVersion();
+    const { currentCacheExists, existingVersion, isFirstInstall } = await checkCacheVersion();
     
     // If current version cache already exists, no need to reinstall
     if (currentCacheExists) {
@@ -65,133 +205,167 @@ const preload = async () => {
         return;
     }
     
-    // If we have an older version, notify clients but don't update yet
-    if (existingVersion && existingVersion !== CACHE_VERSION) {
+    // For updates (not first-time installations), notify but don't update automatically
+    if (!isFirstInstall && existingVersion !== CACHE_VERSION) {
         console.log(`New version ${CACHE_VERSION} available (current: ${existingVersion})`);
         await notifyClients();
         return;
     }
     
-    // If no cache exists at all, do initial installation
-    if (!existingVersion) {
-        await installCache();
+    // First-time installation case - no existing cache
+    if (isFirstInstall) {
+        console.log(`First-time installation: creating cache with version ${CACHE_VERSION}`);
+        await installCache(true); // Pass true to indicate first installation
     }
-};
+}
 
-// Function to install or update the cache
-async function installCache() {
-    console.log(`Installing/updating cache to version ${CACHE_VERSION}`);
+/**
+ * Installs or updates the service worker cache
+ * @param {boolean} isFirstInstall - Whether this is a first-time installation
+ * @returns {Promise<void>}
+ */
+async function installCache(isFirstInstall = false) {
+    console.log(`${isFirstInstall ? 'First-time installation' : 'Updating'} cache to version ${CACHE_VERSION}`);
     const cache = await caches.open(CACHE_NAME);
     
     try {
+        // Clear old caches
+        const { oldCaches } = await checkCacheVersion();
+        if (oldCaches.length > 0) {
+            console.log(`Deleting old caches: ${oldCaches}`);
+            await Promise.all(
+                oldCaches.map(key => caches.delete(key))
+            );
+        }
+
+        // Fetch and cache assets
         console.log("Fetching asset manifest...");
         const response = await fetch(getAssetPath("assets/asset-manifest.json"));
         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-        const assets = await response.json();
         
-        // Add base path to relative URLs
+        const assets = await response.json();
         const processedAssets = assets.map(asset => getAssetPath(asset));
         ASSETS_TO_CACHE.push(...processedAssets);
         
-        // Always include critical files
-        const criticalFiles = [
-            'index.html',
-            'index.js',
-            'styles.css',
-            'assets/manifest.json',
-            'assets/dumbterm.png',
-            'managers/terminal.js',
-            'managers/storage.js'
-        ];
-        
-        criticalFiles.forEach(file => {
-            const filePath = getAssetPath(file);
-            if (!ASSETS_TO_CACHE.includes(filePath)) {
-                ASSETS_TO_CACHE.push(filePath);
-            }
-        });
-        
-        console.log("Assets to cache:", ASSETS_TO_CACHE);
+        console.log("Caching assets:", ASSETS_TO_CACHE);
         await cache.addAll(ASSETS_TO_CACHE);
         console.log("Assets cached successfully");
         
-        // Clear old caches after successful installation
-        const { oldCaches } = await checkCacheVersion();
-        await Promise.all(
-            oldCaches.map(key => {
-                console.log(`Deleting old cache: ${key}`);
-                return caches.delete(key);
-            })
-        );
-
-        // Notify clients of successful update
+        // Notify clients
         self.clients.matchAll().then(clients => {
             clients.forEach(client => {
-                client.postMessage({
-                    type: 'UPDATE_COMPLETE',
-                    version: CACHE_VERSION,
-                    success: true
-                });
+                if (isFirstInstall) {
+                    // For first-time installations, just update the version display
+                    client.postMessage({
+                        type: 'CACHE_VERSION_INFO',
+                        currentVersion: CACHE_VERSION,
+                        cacheName: CACHE_NAME
+                    });
+                } else {
+                    // For updates, notify about completion and update version display
+                    client.postMessage({
+                        type: 'UPDATE_COMPLETE',
+                        version: CACHE_VERSION,
+                        cacheName: CACHE_NAME,
+                        success: true
+                    });
+                    
+                    // Also send specific version info message to maintain compatibility
+                    client.postMessage({
+                        type: 'CACHE_VERSION_INFO',
+                        currentVersion: CACHE_VERSION,
+                        cacheName: CACHE_NAME
+                    });
+                }
             });
         });
     } catch (error) {
         console.error("Failed to cache assets:", error);
-        // Notify clients of failed update
+        
+        // Notify clients of failure
         self.clients.matchAll().then(clients => {
             clients.forEach(client => {
                 client.postMessage({
                     type: 'UPDATE_COMPLETE',
                     version: CACHE_VERSION,
+                    cacheName: CACHE_NAME,
                     success: false,
                     error: error.message
+                });
+                
+                // Still send version info for UI consistency
+                client.postMessage({
+                    type: 'CACHE_VERSION_INFO',
+                    currentVersion: CACHE_VERSION,
+                    cacheName: CACHE_NAME
                 });
             });
         });
     }
 }
 
-self.addEventListener("install", (event) => {
+// Service Worker event listeners
+self.addEventListener("install", event => {
     console.log("Service Worker installing...");
+    
     event.waitUntil(
-        Promise.all([
-            preload(),
-            self.skipWaiting() // Skip waiting to allow new service worker to activate immediately
-        ])
+        // Initialize version first, then skip waiting to activate immediately
+        initializeVersion()
+            .then(() => self.skipWaiting())
+            .catch(error => {
+                console.error("Error during service worker installation:", error);
+            })
     );
 });
 
-self.addEventListener("activate", (event) => {
+self.addEventListener("activate", event => {
     console.log("Service Worker activating...");
+    
     event.waitUntil(
-        Promise.all([
-            self.clients.claim(), // Take control of all clients immediately
-            notifyClients() // Check version and notify clients immediately
-        ])
+        Promise.resolve()
+            .then(async () => {
+                // Take control of all clients
+                await self.clients.claim();
+                
+                // Check cache status
+                const { isFirstInstall } = await checkCacheVersion();
+                
+                // First-time install: set up cache immediately
+                if (isFirstInstall) {
+                    console.log("First-time installation detected, setting up cache");
+                    await preload();
+                } else {
+                    // Existing installation: just notify clients
+                    await notifyClients();
+                }
+            })
+            .catch(error => {
+                console.error("Error during service worker activation:", error);
+            })
     );
 });
 
-self.addEventListener("fetch", (event) => {
+self.addEventListener("fetch", event => {
     event.respondWith(
         caches.match(event.request)
-            .then((cachedResponse) => {
+            .then(cachedResponse => {
                 // Return cached response if found
                 if (cachedResponse) {
                     return cachedResponse;
                 }
 
-                // Clone the request because it can only be used once
+                // Otherwise fetch from network
                 return fetch(event.request.clone())
-                    .then((response) => {
+                    .then(response => {
                         // Don't cache if not a valid response
                         if (!response || response.status !== 200 || response.type !== 'basic') {
                             return response;
                         }
 
-                        // Clone the response because it can only be used once
+                        // Clone the response and cache it
                         const responseToCache = response.clone();
-
                         caches.open(CACHE_NAME)
-                            .then((cache) => {
+                            .then(cache => {
                                 cache.put(event.request, responseToCache);
                             });
 
@@ -199,7 +373,7 @@ self.addEventListener("fetch", (event) => {
                     });
             })
             .catch(() => {
-                // Return a fallback response for navigation requests
+                // Return fallback for navigation requests
                 if (event.request.mode === 'navigate') {
                     return caches.match(getAssetPath('index.html'));
                 }
@@ -211,28 +385,161 @@ self.addEventListener("fetch", (event) => {
     );
 });
 
-// Listen for message events from the main script
-self.addEventListener('message', async (event) => {
-    if (event.data && event.data.type === 'GET_VERSION') {
-        const { existingVersion } = await checkCacheVersion();
-        // Send the current version to the client
-        if (event.ports && event.ports[0]) {
-            event.ports[0].postMessage({
-                currentVersion: existingVersion,
-                newVersion: CACHE_VERSION
-            });
-        }
-    } else if (event.data && event.data.type === 'PERFORM_UPDATE') {
-        // User has confirmed they want to update
-        await installCache();
-        // Notify clients that update is complete
-        self.clients.matchAll().then(clients => {
-            clients.forEach(client => {
-                client.postMessage({
-                    type: 'UPDATE_COMPLETE',
-                    version: CACHE_VERSION
-                });
-            });
-        });
+// Message handling
+self.addEventListener('message', async event => {
+    const { data } = event;
+    
+    if (!data || !data.type) return;
+    
+    switch (data.type) {
+        case 'SET_VERSION':
+            await handleSetVersion(data.version, data.cacheName);
+            break;
+            
+        case 'GET_VERSION':
+            await handleGetVersion(event);
+            break;
+            
+        case 'PERFORM_UPDATE':
+            await handlePerformUpdate();
+            break;
     }
 });
+
+/**
+ * Handles SET_VERSION messages from the client
+ * @param {string} version - Version sent from client
+ * @param {string} cacheName - Optional cache name from client
+ */
+async function handleSetVersion(version, cacheName) {
+    if (!version) return;
+    
+    console.log(`Received version from client: ${version}${cacheName ? `, cacheName: ${cacheName}` : ''}`);
+    
+    // Check current cache status
+    const { existingVersion, isFirstInstall } = await checkCacheVersion();
+    
+    // Only update if non-default version and different from current
+    if (version !== "1.0.0" && version !== CACHE_VERSION) {
+        const previousVersion = CACHE_VERSION;
+        CACHE_VERSION = version;
+        
+        // Use cacheName if provided directly in the message
+        if (cacheName) {
+            CACHE_NAME = cacheName;
+            console.log(`Using cacheName from message: ${CACHE_NAME}`);
+        } else {
+            // Try to get cache name from config as fallback
+            try {
+                const appConfig = await getAppConfig();
+                if (appConfig && appConfig.cacheName) {
+                    CACHE_NAME = appConfig.cacheName;
+                    console.log(`Using cacheName from config: ${CACHE_NAME}`);
+                } else {
+                    // Fall back to constructed cache name if needed
+                    CACHE_NAME = `DUMBTERM_CACHE_V${CACHE_VERSION}`;
+                    console.log(`Constructed cache name: ${CACHE_NAME}`);
+                }
+            } catch (error) {
+                // Fall back to constructed cache name on error
+                CACHE_NAME = `DUMBTERM_CACHE_V${CACHE_VERSION}`;
+                console.log(`Error getting config, using constructed cache name: ${CACHE_NAME}`);
+            }
+        }
+        
+        console.log(`Updated cache version from ${previousVersion} to ${CACHE_VERSION}`);
+        
+        // For first-time installations, install cache immediately
+        if (isFirstInstall) {
+            console.log("First-time installation with SET_VERSION - installing cache");
+            await installCache(true);
+        } 
+        // For meaningful version changes, check if update is needed
+        else if (previousVersion !== "1.0.0") {
+            console.log(`Version change detected: ${previousVersion} → ${CACHE_VERSION}`);
+            await preload();
+        }
+        // Otherwise just update the UI
+        else {
+            await notifyClients();
+        }
+    } else {
+        console.log(`No version change needed, current: ${CACHE_VERSION}`);
+        await notifyClients();
+    }
+}
+
+/**
+ * Handles GET_VERSION messages from the client
+ * @param {MessageEvent} event - Original message event with ports
+ */
+async function handleGetVersion(event) {
+    // Get cache status
+    const { existingVersion, isFirstInstall } = await checkCacheVersion();
+    
+    // If default version, try to get from config
+    if (CACHE_VERSION === "1.0.0") {
+        try {
+            const appConfig = await getAppConfig();
+            if (appConfig) {
+                if (appConfig.cacheName) {
+                    console.log(`Using cacheName from config: ${appConfig.cacheName}`);
+                    CACHE_NAME = appConfig.cacheName;
+                    
+                    // Try to extract version from cacheName
+                    const versionMatch = CACHE_NAME.match(/.*_V(.+)$/) || CACHE_NAME.match(/DUMBTERM_CACHE_(.+)$/);
+                    if (versionMatch && versionMatch[1]) {
+                        CACHE_VERSION = versionMatch[1];
+                        console.log(`Extracted version from cacheName: ${CACHE_VERSION}`);
+                    }
+                }
+                
+                if (appConfig.version && (CACHE_VERSION === "1.0.0" || !appConfig.cacheName)) {
+                    CACHE_VERSION = appConfig.version;
+                    if (!appConfig.cacheName) {
+                        CACHE_NAME = `DUMBTERM_CACHE_V${CACHE_VERSION}`;
+                    }
+                    console.log(`Using version from config: ${CACHE_VERSION}`);
+                }
+            }
+        } catch (error) {
+            console.error("Error getting config version:", error);
+        }
+    }
+    
+    // For first-time installs, report the current version to avoid update prompts
+    const versionToReport = isFirstInstall ? CACHE_VERSION : (existingVersion || CACHE_VERSION);
+    
+    console.log(`Reporting versions - current: ${versionToReport}, new: ${CACHE_VERSION}`);
+    
+    // Create a consistent update available message based on version comparison
+    const updateMessage = {
+        currentVersion: versionToReport,
+        newVersion: CACHE_VERSION,
+        cacheName: CACHE_NAME
+    };
+    
+    // Send version via message channel if available
+    if (event.ports && event.ports[0]) {
+        event.ports[0].postMessage(updateMessage);
+    }
+    
+    // Also broadcast to all clients but only send one type of message to avoid duplicates
+    self.clients.matchAll().then(clients => {
+        clients.forEach(client => {
+            client.postMessage({
+                type: 'CACHE_VERSION_INFO',
+                currentVersion: versionToReport,
+                cacheName: CACHE_NAME
+            });
+        });
+    });
+}
+
+/**
+ * Handles PERFORM_UPDATE messages from the client
+ */
+async function handlePerformUpdate() {
+    console.log("User confirmed update, installing cache");
+    await installCache(false);
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -392,6 +392,7 @@ h2 {
     z-index: 100;
     pointer-events: none;
     margin: 0;
+    font-family: 'FiraCode Nerd Font', monospace;
 }
 
 .dumbware-credit a {
@@ -403,6 +404,29 @@ h2 {
 .dumbware-credit a:hover {
     text-decoration: underline;
     opacity: 0.8;
+}
+
+.version-display {
+    font-size: 0.75rem;
+    opacity: 0.8;
+    color: var(--text);
+}
+
+.version-display.loading::after {
+    content: "";
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-left: 5px;
+    border: 2px solid var(--text);
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 }
 
 .tooltip {

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ const APP_VERSION = require('./package.json').version;
 const PUBLIC_DIR = path.join(__dirname, 'public');
 const ASSETS_DIR = path.join(PUBLIC_DIR, 'assets');
 const ptyModule = DEMO_MODE ? require('./scripts/demo/terminal') : pty;
-const CACHE_NAME = `DUMBTERM_CACHE_${APP_VERSION}`;
+const CACHE_NAME = `DUMBTERM_CACHE_V${APP_VERSION}`;
 
 generatePWAManifest(SITE_TITLE);
 

--- a/server.js
+++ b/server.js
@@ -21,9 +21,11 @@ const NODE_ENV = process.env.NODE_ENV || 'production';
 const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
 const DEMO_MODE = process.env.DEMO_MODE === 'true';
 const SITE_TITLE = DEMO_MODE ? `${process.env.SITE_TITLE || 'DumbTerm'} (DEMO)` : (process.env.SITE_TITLE || 'DumbTerm');
+const APP_VERSION = require('./package.json').version;
 const PUBLIC_DIR = path.join(__dirname, 'public');
 const ASSETS_DIR = path.join(PUBLIC_DIR, 'assets');
 const ptyModule = DEMO_MODE ? require('./scripts/demo/terminal') : pty;
+const CACHE_NAME = `DUMBTERM_CACHE_${APP_VERSION}`;
 
 generatePWAManifest(SITE_TITLE);
 
@@ -192,7 +194,6 @@ app.use(BASE_PATH, (req, res, next) => {
         '/styles.css',
         '/manifest.json',
         '/asset-manifest.json',
-        '/node_modules/@xterm/'
     ];
 
     // Check if the current path matches any of the public paths
@@ -219,7 +220,9 @@ app.get(BASE_PATH + '/config.js', (req, res) => {
         debug: DEBUG,
         siteTitle: SITE_TITLE,
         isPinRequired: isPinRequired,
-        isDemoMode: DEMO_MODE
+        isDemoMode: DEMO_MODE,
+        version: APP_VERSION,
+        cacheName: CACHE_NAME
     }
 
     res.type('application/javascript').send(`
@@ -560,7 +563,9 @@ server.listen(PORT, () => {
         pinProtection: isPinRequired,
         nodeEnv: NODE_ENV,
         debug: DEBUG,
-        demoMode: DEMO_MODE
+        demoMode: DEMO_MODE,
+        version: APP_VERSION,
+        cacheName: CACHE_NAME
     });
     console.log(`Server running on: ${BASE_URL}`);
 });


### PR DESCRIPTION
## Pull Request Overview

Fixes https://github.com/DumbWareio/DumbTerm/issues/25

This PR introduces version tracking and display, updates service worker cache naming, fixes mac option key handling in xterm, and enhances the Docker build/publish workflow with version-based image tags.

- Expose `APP_VERSION` and `CACHE_NAME` on both server and client, plus UI display under terminal.
- Refactor service worker registration into `ServiceWorkerManager` and add version spinner.
- Bump package version to 1.1.1, improve Dockerfile layers, and update CI for multi-platform image tagging.

| File                                        | Description                                                  |
|---------------------------------------------|--------------------------------------------------------------|
| server.js                                   | Define `APP_VERSION`, `CACHE_NAME`, and include in config.   |
| public/styles.css                           | Add `.version-display` styles and spinner keyframes.         |
| public/managers/terminal.js                 | Change `macOptionIsMeta` default to `false`.                 |
| public/index.js                             | Remove old SW code; add `ServiceWorkerManager` and version UI logic. |
| public/index.html                           | Insert `<span id="version-display">` for version display.    |
| package.json                                | Bump version to `1.1.1`.                                     |
| Dockerfile                                  | Optimize layer caching, add production install & shell env.  |
| .github/workflows/docker-publish.yml        | Upgrade actions, extract version, tag images by version/branch. |